### PR TITLE
devise_token_auth導入時のエラー対応

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 class User < ApplicationRecord
+  extend Devise::Models
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -1,7 +1,0 @@
-Devise.setup do |_config|
-  # ==> ORM configuration
-  # Load and configure the ORM. Supports :active_record (default) and
-  # :mongoid (bson_ext recommended) by default. Other ORMs may be
-  # available as additional gems.
-  require "devise/orm/active_record"
-end


### PR DESCRIPTION
## 概要
- `config/initializers/devise.rb`ファイルの削除
- `models/user.rb`に`extend Devise::Models`の記述を追記