### PR TITLE
記事に関するAPIのルーティングの設定

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,9 @@
 Rails.application.routes.draw do
-  mount_devise_token_auth_for "User", at: "auth"
-  # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
+  namespace :api do
+    namespace :v1 do
+      mount_devise_token_auth_for "User", at: "auth"
+      # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
+      resources :articles
+    end
+  end
 end


### PR DESCRIPTION
## 概要
- APIのendpointが`/api/v1`から始まるように`routes.rb`を修正