### PR TITLE
記事に関するbase_api_controllerの実装

### DIFF
--- a/app/controllers/api/v1/base_api_controller.rb
+++ b/app/controllers/api/v1/base_api_controller.rb
@@ -1,0 +1,2 @@
+class Api::V1::BaseApiController < ApplicationController
+end


### PR DESCRIPTION
## 概要
- `/app/controllers/api/v1/base_api_controller.rb`を作成し、`ApplicationController`を継承した`base_api_controller`を実装した