### PR TITLE
記事一覧取得機能の実装

### DIFF
--- a/app/controllers/api/v1/articles_controller.rb
+++ b/app/controllers/api/v1/articles_controller.rb
@@ -1,0 +1,11 @@
+module Api
+  module V1
+    class ArticlesController < Api::V1::BaseApiController
+      def index
+        @articles = Article.all.order("updated_at DESC")
+        # binding.pry
+        render json: @articles, each_serializer: ArticlePreviewSerializer
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/articles_controller.rb
+++ b/app/controllers/api/v1/articles_controller.rb
@@ -2,7 +2,7 @@ module Api
   module V1
     class ArticlesController < Api::V1::BaseApiController
       def index
-        @articles = Article.all.order("updated_at DESC")
+        @articles = Article.order("updated_at DESC")
         # binding.pry
         render json: @articles, each_serializer: ArticlePreviewSerializer
       end

--- a/app/serializers/api/v1/article_preview_serializer.rb
+++ b/app/serializers/api/v1/article_preview_serializer.rb
@@ -1,0 +1,12 @@
+module Api
+  module V1
+    class ArticlePreviewSerializer < ActiveModel::Serializer
+      attributes :id, :title
+
+      has_many :comments
+      has_many :likes
+
+      belongs_to :user
+    end
+  end
+end

--- a/app/serializers/article_serializer.rb
+++ b/app/serializers/article_serializer.rb
@@ -1,0 +1,3 @@
+class ArticleSerializer < ActiveModel::Serializer
+  attributes :id
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,9 +1,11 @@
 Rails.application.routes.draw do
+  # get 'articles/index'
   namespace :api do
     namespace :v1 do
       mount_devise_token_auth_for "User", at: "auth"
       # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
       resources :articles
+      resources :articles, defaults: { format: :json }
     end
   end
 end

--- a/spec/factories/articles.rb
+++ b/spec/factories/articles.rb
@@ -19,8 +19,8 @@
 #
 FactoryBot.define do
   factory :article do
-    title { "記事タイトル" }
-    content { "記事本文" }
+    sequence(:title) { |n| "記事タイトル#{n}" }
+    sequence(:content) { |n| "記事本文#{n}" }
     user
     # association :user, factory: :user
   end

--- a/spec/factories/articles.rb
+++ b/spec/factories/articles.rb
@@ -19,8 +19,8 @@
 #
 FactoryBot.define do
   factory :article do
-    sequence(:title) { |n| "記事タイトル#{n}" }
-    sequence(:content) { |n| "記事本文#{n}" }
+    sequence(:title) {|n| "記事タイトル#{n}" }
+    sequence(:content) {|n| "記事本文#{n}" }
     user
     # association :user, factory: :user
   end

--- a/spec/requests/api/v1/articles_spec.rb
+++ b/spec/requests/api/v1/articles_spec.rb
@@ -1,0 +1,20 @@
+require 'rails_helper'
+
+RSpec.describe "Api::V1::Articles", type: :request do
+  describe "GET /api/v1/articles" do
+    subject { get(api_v1_articles_path) } #記事一覧取得:indexメソッドのpathへアクセスする
+    before { 3.times { FactoryBot.create(:article) } } # FactoryBotを介して記事情報を3つ作成
+    fit "記事の一覧が取得できる" do
+      subject
+
+      # 記事情報がすべて返ってきていること
+      res = JSON.parse(response.body)
+      expect(res.length).to eq 3
+      # 返ってきた記事データがtitleのデータを持つこと
+      expect(res[0].keys).to include "title"
+      # ステータスコードが200であること
+      expect(response).to have_http_status(200)
+
+    end
+  end
+end

--- a/spec/requests/api/v1/articles_spec.rb
+++ b/spec/requests/api/v1/articles_spec.rb
@@ -1,20 +1,27 @@
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe "Api::V1::Articles", type: :request do
   describe "GET /api/v1/articles" do
-    subject { get(api_v1_articles_path) } #記事一覧取得:indexメソッドのpathへアクセスする
+    subject { get(api_v1_articles_path) } # 記事一覧取得:indexメソッドのpathへアクセスする
+
     before { 3.times { FactoryBot.create(:article) } } # FactoryBotを介して記事情報を3つ作成
-    fit "記事の一覧が取得できる" do
+
+    # rubocop推奨のため、"記事の一覧が取得できる"テストを分割表示した
+    it "記事情報がすべて返ってきていること" do
       subject
-
-      # 記事情報がすべて返ってきていること
-      res = JSON.parse(response.body)
+      res = response.parsed_body # res = JSON.parse(response.body) rubocopにより推奨
       expect(res.length).to eq 3
-      # 返ってきた記事データがtitleのデータを持つこと
-      expect(res[0].keys).to include "title"
-      # ステータスコードが200であること
-      expect(response).to have_http_status(200)
+    end
 
+    it "返ってきた記事データがtitleのデータを持つこと" do
+      subject
+      res = response.parsed_body # res = JSON.parse(response.body) rubocopにより推奨
+      expect(res[0].keys).to include "title"
+    end
+
+    it "ステータスコードが200であること" do
+      subject
+      expect(response).to have_http_status(200)
     end
   end
 end


### PR DESCRIPTION
## 概要
- `/app/serializers/api/v1/article_preview_serializer.rb`を作成し、`active_model_serializer`を用いて記事一覧を json で返す機能を実装
- endpointと階層を一致させるため、`articles_controller`を`controller/api/v1`配下に移動
- 記事一覧を更新日の降順で取得するように実装
- `articles_controller`と階層を一致させるため、`articles_spec.rb`を`spec/requests/api/v1`配下に移動
- `articles_spec.rb`におけるテスト実装によりindexの記事一覧の取得が可能か確認