### PR TITLE
記事詳細取得機能の実装

### DIFF
--- a/app/controllers/api/v1/articles_controller.rb
+++ b/app/controllers/api/v1/articles_controller.rb
@@ -5,7 +5,19 @@ module Api
         @articles = Article.order("updated_at DESC")
         # binding.pry
         render json: @articles, each_serializer: ArticlePreviewSerializer
+        # renderメソッド使用時に、デフォルトではない上記シリアライザーを指定した
       end
-    end
+
+      def show
+        @article = Article.find(params[:id])
+        # binding.pry
+        render json: @article, each_serializer: ArticleSerializer
+      end
+
+      private
+        def article_params
+          params.require(:article).permit(:title, :content)
+        end
+      end
   end
 end

--- a/app/controllers/api/v1/articles_controller.rb
+++ b/app/controllers/api/v1/articles_controller.rb
@@ -15,9 +15,10 @@ module Api
       end
 
       private
+
         def article_params
           params.require(:article).permit(:title, :content)
         end
-      end
+    end
   end
 end

--- a/app/serializers/api/v1/article_serializer.rb
+++ b/app/serializers/api/v1/article_serializer.rb
@@ -1,0 +1,12 @@
+module Api
+  module V1
+    class ArticleSerializer < ActiveModel::Serializer
+      attributes :id, :title, :content
+
+      has_many :comments
+      has_many :likes
+
+      belongs_to :user
+    end
+  end
+end

--- a/app/serializers/article_serializer.rb
+++ b/app/serializers/article_serializer.rb
@@ -1,3 +1,0 @@
-class ArticleSerializer < ActiveModel::Serializer
-  attributes :id
-end

--- a/spec/requests/api/v1/articles_spec.rb
+++ b/spec/requests/api/v1/articles_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe "Api::V1::Articles", type: :request do
     # before { 3.times { FactoryBot.create(:article) } } # FactoryBotを介して記事情報を3つ作成
     # before { create_list(:article, 3) } # FactoryBotのcreate_listメソッドを用いた記述に変更
     before { create_list(:article, article_count) } # letを用いた記述に変更
+
     let(:article_count) { 3 }
 
     # rubocop推奨のため、"記事の一覧が取得できる"テストを分割表示した
@@ -30,16 +31,23 @@ RSpec.describe "Api::V1::Articles", type: :request do
 
   describe "GET /api/v1/articles/:id" do
     subject { get(api_v1_article_path(article_id)) } # 記事詳細取得:showメソッドのpathへアクセスする（ルーティング確認）、詳細なのでidを指定するためarticle_id（letで定義した変数）を追記
+
     context "指定したidの記事が存在するとき" do
       let(:article_id) { article.id }
       let(:article) { FactoryBot.create(:article) }
 
-      # rubocop推奨のため、"その記事のレコードが取得できる"というテストを2つに分割した
-      it "指定したidの記事データが返ってくること" do # リクエスト情報と返ってきた記事データが一致すること
+      # rubocop推奨のため、"その記事のレコードが取得できる"というテストを2つに分割　"指定したidの記事データが返ってくること"と"ステータスコードが200であること"
+      # さらに"指定したidの記事データが返ってくること"を2つに分割した
+      it "指定したidの記事データのうちタイトルが返ってくること" do # リクエストデータと返ってきた記事データが一致すること
         subject
         res = response.parsed_body # res = JSON.parse(response.body) rubocopにより推奨
         # binding.pry
         expect(res["title"]).to eq article.title
+      end
+
+      it "指定したidの記事データのうち本文が返ってくること" do
+        subject
+        res = response.parsed_body # res = JSON.parse(response.body) rubocopにより推奨
         expect(res["content"]).to eq article.content
       end
 
@@ -50,11 +58,11 @@ RSpec.describe "Api::V1::Articles", type: :request do
     end
 
     context "指定したidの記事が存在しないとき" do
-    let(:article_id) { 100000 } # 被らないidを指定するため、大きい数値を記述した
+      let(:article_id) { 100000 } # 被らないidを指定するため、大きい数値を記述した
 
       it "記事のレコードが見つからない" do
         # binding.pry
-        expect{ subject }.to raise_error(ActiveRecord::RecordNotFound)
+        expect { subject }.to raise_error(ActiveRecord::RecordNotFound)
       end
     end
   end

--- a/spec/requests/api/v1/articles_spec.rb
+++ b/spec/requests/api/v1/articles_spec.rb
@@ -2,9 +2,12 @@ require "rails_helper"
 
 RSpec.describe "Api::V1::Articles", type: :request do
   describe "GET /api/v1/articles" do
-    subject { get(api_v1_articles_path) } # 記事一覧取得:indexメソッドのpathへアクセスする
+    subject { get(api_v1_articles_path) } # 記事一覧取得:indexメソッドのpathへアクセスする（ルーティング確認）
 
-    before { 3.times { FactoryBot.create(:article) } } # FactoryBotを介して記事情報を3つ作成
+    # before { 3.times { FactoryBot.create(:article) } } # FactoryBotを介して記事情報を3つ作成
+    # before { create_list(:article, 3) } # FactoryBotのcreate_listメソッドを用いた記述に変更
+    before { create_list(:article, article_count) } # letを用いた記述に変更
+    let(:article_count) { 3 }
 
     # rubocop推奨のため、"記事の一覧が取得できる"テストを分割表示した
     it "記事情報がすべて返ってきていること" do
@@ -22,6 +25,37 @@ RSpec.describe "Api::V1::Articles", type: :request do
     it "ステータスコードが200であること" do
       subject
       expect(response).to have_http_status(200)
+    end
+  end
+
+  describe "GET /api/v1/articles/:id" do
+    subject { get(api_v1_article_path(article_id)) } # 記事詳細取得:showメソッドのpathへアクセスする（ルーティング確認）、詳細なのでidを指定するためarticle_id（letで定義した変数）を追記
+    context "指定したidの記事が存在するとき" do
+      let(:article_id) { article.id }
+      let(:article) { FactoryBot.create(:article) }
+
+      # rubocop推奨のため、"その記事のレコードが取得できる"というテストを2つに分割した
+      it "指定したidの記事データが返ってくること" do # リクエスト情報と返ってきた記事データが一致すること
+        subject
+        res = response.parsed_body # res = JSON.parse(response.body) rubocopにより推奨
+        # binding.pry
+        expect(res["title"]).to eq article.title
+        expect(res["content"]).to eq article.content
+      end
+
+      it "ステータスコードが200であること" do
+        subject
+        expect(response).to have_http_status(200)
+      end
+    end
+
+    context "指定したidの記事が存在しないとき" do
+    let(:article_id) { 100000 } # 被らないidを指定するため、大きい数値を記述した
+
+      it "記事のレコードが見つからない" do
+        # binding.pry
+        expect{ subject }.to raise_error(ActiveRecord::RecordNotFound)
+      end
     end
   end
 end


### PR DESCRIPTION
## 概要
- `show`メソッドに対応した`active_model_serilalizers`として`article_serializer.rb`を実装
- `articles_controller`への`show`メソッドの実装
- 記事一覧取得機能のテスト内容のリファクタリング
- 記事詳細取得機能のテストの実装