### PR TITLE
記事作成機能の実装

### DIFF
--- a/app/controllers/api/v1/articles_controller.rb
+++ b/app/controllers/api/v1/articles_controller.rb
@@ -14,6 +14,12 @@ module Api
         render json: @article, each_serializer: ArticleSerializer
       end
 
+      def create
+        # current_user（User.firstのユーザー）に紐づけられた新規記事のインスタンスを生成・保存する
+        @article = current_user.articles.create!(article_params)
+        render json: @article, each_serializer: ArticleSerializer
+      end
+
       private
 
         def article_params

--- a/app/controllers/api/v1/base_api_controller.rb
+++ b/app/controllers/api/v1/base_api_controller.rb
@@ -1,2 +1,12 @@
-class Api::V1::BaseApiController < ApplicationController
+module Api
+  module V1
+    class BaseApiController < ApplicationController
+      # 仮実装用のコード
+      def current_user
+        # usersテーブルの一番初めのユーザー情報を取ってくる
+        @current_user = User.first
+        # binding.pry
+      end
+    end
+  end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,3 +1,4 @@
 class ApplicationController < ActionController::Base
   include DeviseTokenAuth::Concerns::SetUserByToken
+  protect_from_forgery with: :null_session
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -38,6 +38,7 @@ module WonderfulEditor
     end
 
     config.api_only = true
+    config.middleware.use ActionDispatch::Flash
 
     # Configuration for the application, engines, and railties goes here.
     #


### PR DESCRIPTION
## 概要
- `base_api_controller`に`current_user`メソッドを仮実装
- `create`メソッドの実装
- CSRF対策をOFFに設定
- `500 Error`への対応