### PR TITLE
devise_token_authに関連するAPIの修正

### DIFF
--- a/app/controllers/api/v1/articles_controller.rb
+++ b/app/controllers/api/v1/articles_controller.rb
@@ -1,6 +1,8 @@
 module Api
   module V1
     class ArticlesController < Api::V1::BaseApiController
+      before_action :authenticate_user!, only: [:create, :update, :destroy]
+
       def index
         @articles = Article.order("updated_at DESC")
         # binding.pry
@@ -15,8 +17,9 @@ module Api
       end
 
       def create
-        # current_user（User.firstのユーザー）に紐づけられた新規記事のインスタンスを生成・保存する
+        # current_userに紐づけられた新規記事のインスタンスを生成・保存する
         @article = current_user.articles.create!(article_params)
+        # binding.pry
         render json: @article, each_serializer: ArticleSerializer
       end
 

--- a/app/controllers/api/v1/base_api_controller.rb
+++ b/app/controllers/api/v1/base_api_controller.rb
@@ -2,10 +2,22 @@ module Api
   module V1
     class BaseApiController < ApplicationController
       # 仮実装用のコード
+      # def current_user
+      #   # usersテーブルの一番初めのユーザー情報を取ってくる
+      #   @current_user = User.first
+      #   binding.pry
+      # end
+
       def current_user
-        # usersテーブルの一番初めのユーザー情報を取ってくる
-        @current_user = User.first
-        # binding.pry
+        current_api_v1_user
+      end
+
+      def user_signed_in?
+        api_v1_user_signed_in?
+      end
+
+      def authenticate_user!
+        authenticate_api_v1_user!
       end
     end
   end


### PR DESCRIPTION
## 概要
- `app/controllers/api/v1/articles_controller.rb`における認証機能の追加
- `app/controllers/api/v1/base_api_controller.rb`における仮実装用コードの削除及びデフォルトヘルパーメソッドの上書き
- `spec/requests/api/v1/articles_spec.rb`のうち、新規記事作成、更新、削除に関わるテストの修正（モックの削除及び認証機能の追加）