### PR TITLE
Articleモデルに下書き機能の実装

### DIFF
--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -4,10 +4,11 @@
 #
 #  id         :bigint           not null, primary key
 #  content    :text
+#  status     :integer          default("draft"), not null
 #  title      :string
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
-#  user_id    :bigint           not null
+#  user_id    :bigint
 #
 # Indexes
 #
@@ -25,4 +26,7 @@ class Article < ApplicationRecord
 
   validates :title, presence: true
   validates :content, presence: true
+
+  # 記事の状態：draft（下書き）、published（公開）
+  enum status: { draft: 0, published: 1 }
 end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -6,8 +6,8 @@
 #  content    :text
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
-#  article_id :bigint           not null
-#  user_id    :bigint           not null
+#  article_id :bigint
+#  user_id    :bigint
 #
 # Indexes
 #

--- a/app/models/like.rb
+++ b/app/models/like.rb
@@ -5,8 +5,8 @@
 #  id         :bigint           not null, primary key
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
-#  article_id :bigint           not null
-#  user_id    :bigint           not null
+#  article_id :bigint
+#  user_id    :bigint
 #
 # Indexes
 #

--- a/db/migrate/20240627112252_add_user_id_to_articles.rb
+++ b/db/migrate/20240627112252_add_user_id_to_articles.rb
@@ -1,5 +1,9 @@
 class AddUserIdToArticles < ActiveRecord::Migration[6.1]
   def change
     add_reference :articles, :user, foreign_key: true
+
+    # articlesテーブルに新たにstatus（記事の状態を表す）カラムを追加する
+    # integer型、カラム生成時の値は空のため、null: falseとし、デフォルト値は0（draft）とした
+    add_column :articles, :status, :integer, default: 0, null: false
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -20,7 +20,8 @@ ActiveRecord::Schema.define(version: 2024_06_30_035545) do
     t.text "content"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.bigint "user_id", null: false
+    t.bigint "user_id"
+    t.integer "status", default: 0, null: false
     t.index ["user_id"], name: "index_articles_on_user_id"
   end
 
@@ -28,8 +29,8 @@ ActiveRecord::Schema.define(version: 2024_06_30_035545) do
     t.text "content"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.bigint "user_id", null: false
-    t.bigint "article_id", null: false
+    t.bigint "user_id"
+    t.bigint "article_id"
     t.index ["article_id"], name: "index_comments_on_article_id"
     t.index ["user_id"], name: "index_comments_on_user_id"
   end
@@ -37,8 +38,8 @@ ActiveRecord::Schema.define(version: 2024_06_30_035545) do
   create_table "likes", force: :cascade do |t|
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.bigint "user_id", null: false
-    t.bigint "article_id", null: false
+    t.bigint "user_id"
+    t.bigint "article_id"
     t.index ["article_id"], name: "index_likes_on_article_id"
     t.index ["user_id"], name: "index_likes_on_user_id"
   end

--- a/spec/factories/articles.rb
+++ b/spec/factories/articles.rb
@@ -4,10 +4,11 @@
 #
 #  id         :bigint           not null, primary key
 #  content    :text
+#  status     :integer          default("draft"), not null
 #  title      :string
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
-#  user_id    :bigint           not null
+#  user_id    :bigint
 #
 # Indexes
 #
@@ -23,5 +24,13 @@ FactoryBot.define do
     sequence(:content) {|n| "記事本文#{n}" }
     user
     # association :user, factory: :user
+
+    trait :draft do
+      status { :draft }
+    end
+
+    trait :published do
+      status { :published }
+    end
   end
 end

--- a/spec/factories/comments.rb
+++ b/spec/factories/comments.rb
@@ -6,8 +6,8 @@
 #  content    :text
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
-#  article_id :bigint           not null
-#  user_id    :bigint           not null
+#  article_id :bigint
+#  user_id    :bigint
 #
 # Indexes
 #

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -4,10 +4,11 @@
 #
 #  id         :bigint           not null, primary key
 #  content    :text
+#  status     :integer          default("draft"), not null
 #  title      :string
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
-#  user_id    :bigint           not null
+#  user_id    :bigint
 #
 # Indexes
 #
@@ -23,10 +24,18 @@ RSpec.describe Article, type: :model do
   # pending "add some examples to (or delete) #{__FILE__}"
 
   context "titleカラム及びcontentカラムを指定しているとき" do
-    it "記事が作成される" do
+    it "下書き記事が作成される" do
       FactoryBot.create(:user)
       # user = User.create!(name: "foo", password: "fooooo", email: "foo@example.com")
-      article = FactoryBot.build(:article)
+      article = FactoryBot.build(:article, :draft)
+      # article = user.articles.new(title: "abc", content: "abc")
+      expect(article).to be_valid
+    end
+
+    it "公開記事が作成される" do
+      FactoryBot.create(:user)
+      # user = User.create!(name: "foo", password: "fooooo", email: "foo@example.com")
+      article = FactoryBot.build(:article, :published)
       # article = user.articles.new(title: "abc", content: "abc")
       expect(article).to be_valid
     end

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -6,8 +6,8 @@
 #  content    :text
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
-#  article_id :bigint           not null
-#  user_id    :bigint           not null
+#  article_id :bigint
+#  user_id    :bigint
 #
 # Indexes
 #


### PR DESCRIPTION
## 概要
- `app/models/article.rb`にenum機能の追記
- `uses`テーブルに`status`カラムの追加
- `spec/factories/articles.rb`に`statusカラム`の付与に関する記述の追加
- `spec/models/article_spec.rb`に下書き機能のテストの実装