### PR TITLE
自身の公開記事の一覧取得機能の実装

### DIFF
--- a/app/controllers/api/v1/current/articles_controller.rb
+++ b/app/controllers/api/v1/current/articles_controller.rb
@@ -1,0 +1,9 @@
+class Api::V1::Current::ArticlesController < Api::V1::BaseApiController
+  def index
+    # 下書きの記事を更新日順に取得する
+    @articles = Article.published.order("updated_at DESC")
+    # binding.pry
+    render json: @articles, each_serializer: Api::V1::ArticleSerializer
+    # renderメソッド使用時に、デフォルトではない上記シリアライザーを指定した
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,6 +16,10 @@ Rails.application.routes.draw do
         resources :drafts, only: [:index, :show]
       end
 
+      namespace :current do
+        resources :articles, only: [:index]
+      end
+
       resources :articles
     end
   end

--- a/spec/requests/api/v1/articles/drafts_spec.rb
+++ b/spec/requests/api/v1/articles/drafts_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe "Api::V1::Articles::Drafts", type: :request do
       subject
       res = response.parsed_body # res = JSON.parse(response.body) rubocopにより推奨
       # binding.pry
-      # 取得した記事のそれぞれのstatusがpublishedであること
+      # 取得した記事のそれぞれのstatusがdraftであること
       res.each do |article|
         expect(article["status"]).to eq "draft"
       end

--- a/spec/requests/api/v1/current/articles_spec.rb
+++ b/spec/requests/api/v1/current/articles_spec.rb
@@ -1,0 +1,33 @@
+require "rails_helper"
+
+RSpec.describe "Api::V1::Current::Articles", type: :request do
+  describe "GET /api/v1/current/articles" do
+    subject { get(api_v1_current_articles_path) } # 記事一覧取得:indexメソッドのpathへアクセスする（ルーティング確認）
+
+    before { 3.times { FactoryBot.create(:article, :published) } } # FactoryBotを介して公開の記事情報を3つ作成
+
+    # rubocop推奨のため、"記事の一覧が取得できる"テストを分割表示した
+    it "公開の記事情報がすべて返ってきていること" do
+      # binding.pry
+      subject
+      res = response.parsed_body # res = JSON.parse(response.body) rubocopにより推奨
+      # binding.pry
+      expect(res.length).to eq 3
+    end
+
+    it "公開の記事のstatusがpublishedであること" do
+      subject
+      res = response.parsed_body # res = JSON.parse(response.body) rubocopにより推奨
+      # binding.pry
+      # 取得した記事のそれぞれのstatusがpublishedであること
+      res.each do |article|
+        expect(article["status"]).to eq "published"
+      end
+    end
+
+    it "ステータスコードが200であること" do
+      subject
+      expect(response).to have_http_status(200)
+    end
+  end
+end


### PR DESCRIPTION
## 概要
- `config/routes.rb`におけるendpointの修正及びルーティングの追加
- `app/controllers/api/v1/current/articles_controller.rb`における公開記事の一覧取得機能の実装
- `spec/requests/api/v1/current/articles_spec.rb`における上記機能のテストの実装