### PR TITLE
自身の下書き記事及び公開記事の取得機能の修正

### DIFF
--- a/app/controllers/api/v1/articles/drafts_controller.rb
+++ b/app/controllers/api/v1/articles/drafts_controller.rb
@@ -2,11 +2,11 @@ module Api
   module V1
     module Articles
       class DraftsController < Api::V1::BaseApiController
-        # before_action :authenticate_user!
+        before_action :authenticate_user!
 
         def index
           # 下書きの記事を更新日順に取得する
-          @articles = Article.draft.order("updated_at DESC")
+          @articles = current_user.articles.draft.order("updated_at DESC")
           # binding.pry
           render json: @articles, each_serializer: ArticlePreviewSerializer
           # renderメソッド使用時に、デフォルトではない上記シリアライザーを指定した
@@ -14,7 +14,7 @@ module Api
 
         def show
           # 指定したidの下書きの記事を取得する
-          @article = Article.draft.find(params[:id])
+          @article = current_user.articles.draft.find(params[:id])
           # binding.pry
           render json: @article, each_serializer: ArticleSerializer
         end

--- a/app/controllers/api/v1/current/articles_controller.rb
+++ b/app/controllers/api/v1/current/articles_controller.rb
@@ -1,7 +1,9 @@
 class Api::V1::Current::ArticlesController < Api::V1::BaseApiController
+  before_action :authenticate_user!
+
   def index
-    # 下書きの記事を更新日順に取得する
-    @articles = Article.published.order("updated_at DESC")
+    # 公開記事を更新日順に取得する
+    @articles = current_user.articles.published.order("updated_at DESC")
     # binding.pry
     render json: @articles, each_serializer: Api::V1::ArticleSerializer
     # renderメソッド使用時に、デフォルトではない上記シリアライザーを指定した

--- a/spec/requests/api/v1/articles/drafts_spec.rb
+++ b/spec/requests/api/v1/articles/drafts_spec.rb
@@ -2,9 +2,14 @@ require "rails_helper"
 
 RSpec.describe "Api::V1::Articles::Drafts", type: :request do
   describe "GET /api/v1/articles/drafts" do
-    subject { get(api_v1_articles_drafts_path) } # 記事一覧取得:indexメソッドのpathへアクセスする（ルーティング確認）
+    subject {
+      get(api_v1_articles_drafts_path, headers: headers)
+    } # 記事一覧取得:indexメソッドのpathへアクセスする（ルーティング確認）、認証に必要なheaders情報である4つ（access-token,client,expiry,uid）を英クエストとして送る
 
-    before { 3.times { FactoryBot.create(:article, :draft) } } # FactoryBotを介して下書きの記事情報を3つ作成
+    let(:user) { FactoryBot.create(:user) } # ユーザーを作成
+    let!(:articles) { 3.times { FactoryBot.create(:article, :draft, user: user) } } # FactoryBotを介して下書きの記事を3つ作成し、ユーザーに関連付ける
+
+    let(:headers) { user.create_new_auth_token } # 認証に必要なheaders情報である4つ（access-token,client,expiry,uid）を取得する
 
     # rubocop推奨のため、"記事の一覧が取得できる"テストを分割表示した
     it "下書きの記事情報がすべて返ってきていること" do
@@ -32,12 +37,14 @@ RSpec.describe "Api::V1::Articles::Drafts", type: :request do
   end
 
   describe "GET /api/v1/articles/drafts/:id" do
-    subject { get(api_v1_articles_draft_path(article_id)) } # 記事詳細取得:showメソッドのpathへアクセスする（ルーティング確認）、詳細なのでidを指定するためarticle_id（letで定義した変数）を追記
+    subject { get(api_v1_articles_draft_path(article_id), headers: headers) } # 記事詳細取得:showメソッドのpathへアクセスする（ルーティング確認）、詳細なのでidを指定するためarticle_id（letで定義した変数）を追記
+
+    let(:user) { FactoryBot.create(:user) } # ユーザーを作成
+    let(:headers) { user.create_new_auth_token } # 認証に必要なheaders情報である4つ（access-token,client,expiry,uid）を取得する
+    let(:article) { FactoryBot.create(:article, :draft, user: user) } # FactoryBotを介して下書きの記事を作成し、ユーザーに関連付ける
+    let(:article_id) { article.id } # 作成した記事のIDをarticle_idに入れる、定義する
 
     context "指定したidの下書きの記事が存在するとき" do
-      let(:article_id) { article.id }
-      let(:article) { FactoryBot.create(:article, :draft) }
-
       # rubocop推奨のため、"その記事のレコードが取得できる"というテストを2つに分割　"指定したidの記事データが返ってくること"と"ステータスコードが200であること"
       # さらに"指定したidの記事データが返ってくること"を2つに分割した
       it "指定したidの下書きの記事データのうちタイトルが返ってくること" do # リクエストデータと返ってきた記事データが一致すること

--- a/spec/requests/api/v1/current/articles_spec.rb
+++ b/spec/requests/api/v1/current/articles_spec.rb
@@ -2,9 +2,14 @@ require "rails_helper"
 
 RSpec.describe "Api::V1::Current::Articles", type: :request do
   describe "GET /api/v1/current/articles" do
-    subject { get(api_v1_current_articles_path) } # 記事一覧取得:indexメソッドのpathへアクセスする（ルーティング確認）
+    subject {
+      get(api_v1_current_articles_path, headers: headers)
+    } # 記事一覧取得:indexメソッドのpathへアクセスする（ルーティング確認）、認証に必要なheaders情報である4つ（access-token,client,expiry,uid）を英クエストとして送る
 
-    before { 3.times { FactoryBot.create(:article, :published) } } # FactoryBotを介して公開の記事情報を3つ作成
+    let(:user) { FactoryBot.create(:user) } # ユーザーを作成
+    let!(:articles) { 3.times { FactoryBot.create(:article, :published, user: user) } } # FactoryBotを介して公開記事を3つ作成し、ユーザーに関連付ける
+
+    let(:headers) { user.create_new_auth_token } # 認証に必要なheaders情報である4つ（access-token,client,expiry,uid）を取得する
 
     # rubocop推奨のため、"記事の一覧が取得できる"テストを分割表示した
     it "公開の記事情報がすべて返ってきていること" do


### PR DESCRIPTION
## 概要
- 自身の下書き記事取得機能の修正として、`app/controllers/api/v1/articles/drafts_controller.rb`及び`spec/requests/api/v1/articles/drafts_spec.rb`の記述の変更
- 自身の公開記事取得機能の修正として、`app/controllers/api/v1/current/articles_controller.rb`及び`spec/requests/api/v1/current/articles_spec.rb`の記述の変更